### PR TITLE
Use Environment Variables for UDP Ports + debug logs

### DIFF
--- a/src/aioice/ice.py
+++ b/src/aioice/ice.py
@@ -890,8 +890,8 @@ class Connection:
         :param max_port: Maximum port number to use.
         :return: The transport and protocol instances.
         """
-        min_port = int(os.getenv('NOMAD_PORT_webrtc_min', 32768))
-        max_port = int(os.getenv('NOMAD_PORT_webrtc_max', 60999))
+        min_port = int(os.getenv('UDP_PORT_RANGE_START', 32768))
+        max_port = int(os.getenv('UDP_PORT_RANGE_STOP', 60999))
         self.__log_debug(f"Port range for datagram endpoints: {min_port} - {max_port}")
         
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
Environment variables used: `[UDP_PORT_START_RANGE, UDP_PORT_END_RANGE]`
These define the start and end (inclusive) of range to use to allocate ports for datagram connections.

Also, added a debug logger in `Connection` class